### PR TITLE
Fix to get outcomes back to CLI from cloud

### DIFF
--- a/src/presenter/apiDecoratingAdapter.js
+++ b/src/presenter/apiDecoratingAdapter.js
@@ -178,6 +178,7 @@ const requestOutcomes = async () => {
   await gotPt.get('outcomes', {
     responseType: 'buffer',
     resolveBodyOnly: true,
+    headers: { Accept: 'application/zip' },
     retry: {
       // Outcomes file may not be ready yet, so retry
       statusCodes: [...options.retry.statusCodes, 404],


### PR DESCRIPTION
This along with changes to the AWS API Gateway
allow the outcomes file to be fetched as binary.

### Checklist

* [x] I have read the contributing guidelines
* [x] I have read the documentation
* [x] I have included a descriptive Pull Request title
* [x] I have included a Pull Request description of my changes
* [x] I have included tests where/when required (see contributing guidelines)
* [x] I have included documentation modifications/additions where/when required (see contributing guidelines)  
   No, but will do
